### PR TITLE
feat: MarkmapSave default path

### DIFF
--- a/lua/markmap/init.lua
+++ b/lua/markmap/init.lua
@@ -27,7 +27,8 @@ M.setup = function(opts)
   cmd("MarkmapSave", function()
     config = vim.g.markmap_config
     arguments = utils.reset_arguments()
-    table.insert(arguments, "--no-open")          -- specific to this command
+    arguments[2] = vim.fn.expand("%:p:r") .. ".html" -- by default save to open buf location
+    table.insert(arguments, "--no-open") -- specific to this command
     table.insert(arguments, vim.fn.expand("%:p")) -- current buffer path
     if job ~= nil then jobstop(job) end           -- kill jobs
     job = jobstart(config.markmap_cmd, arguments)


### PR DESCRIPTION
Instead of saving to TEMP when html_output is not specified, save the .html to the directory of the current open buffer. This is likely a more convenient default for most users.